### PR TITLE
add --with-cmark-gfm and use internal linkage tclcmark_calloc

### DIFF
--- a/configure
+++ b/configure
@@ -737,6 +737,7 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 with_tcl
+with_cmark_gfm
 with_tclinclude
 enable_threads
 enable_shared
@@ -1392,6 +1393,7 @@ Optional Packages:
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-tcl              directory containing tcl configuration
                           (tclConfig.sh)
+  --with-cmark-gfm=DIR    installation directory of cmark-gfm
   --with-tclinclude       directory containing the public Tcl header files
   --with-celib=DIR        use Windows/CE support library from DIR
 
@@ -5343,21 +5345,39 @@ done
 #-----------------------------------------------------------------------
 
 
+
+# Check whether --with-cmark-gfm was given.
+if test "${with_cmark_gfm+set}" = set; then :
+  withval=$with_cmark_gfm; with_cmark_gfm="${withval}"
+fi
+
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for cmark-gfm installation" >&5
 $as_echo_n "checking for cmark-gfm installation... " >&6; }
+    HAVECMARK=0
     CMARK_LIBS=""
-    HAVECMARK=`pkg-config --exists libcmark-gfm && echo "1"`
+    if test x"${with_cmark_gfm}" != x ; then
+        HAVECMARK=2
+        CMARK_CFLAGS="-I${with_cmark_gfm}/include"
+        CMARK_LIBS="${with_cmark_gfm}/lib/libcmark-gfm-extensions.a ${with_cmark_gfm}/lib/libcmark-gfm.a"
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: ${with_cmark_gfm}" >&5
+$as_echo "${with_cmark_gfm}" >&6; }
+    else
+        HAVECMARK=`pkg-config --exists libcmark-gfm && echo "1"`
+    fi
+
     if test "$HAVECMARK" = "1" ; then
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: found" >&5
 $as_echo "found" >&6; }
         if test "${TEA_PLATFORM}" = "windows" ; then
             CMARK_CFLAGS="`pkg-config --cflags libcmark-gfm`"
-            CMARK_LIBS="-Wl,-Bstatic `pkg-config --static --libs libcmark-gfm` -lcmark-gfm-extensions -Wl,-Bdynamic"
+            CMARK_LIBS="-Wl,-Bstatic `pkg-config --static --libs libcmark-gfm` -lcmark-gfmextensions -Wl,-Bdynamic"
         else
             CMARK_CFLAGS="`pkg-config --cflags libcmark-gfm`"
-            CMARK_LIBS="`pkg-config --libs libcmark-gfm` -lcmark-gfm-extensions"
+            CMARK_LIBS="`pkg-config --libs libcmark-gfm` -lcmark-gfmextensions"
         fi
-    else
+    fi
+
+    if test x"${CMARK_LIBS}" = x ; then
         as_fn_error $? "The required lib libcmark-gfm not found" "$LINENO" 5
     fi
 

--- a/generic/tclcmark.c
+++ b/generic/tclcmark.c
@@ -20,7 +20,7 @@
 
 extern DLLEXPORT int Cmark_Init(Tcl_Interp * interp);
 
-Tcl_Config tclcmark_config[] = {
+static Tcl_Config tclcmark_config[] = {
     {"cmark,version", CMARK_GFM_VERSION_STRING},
     {NULL, NULL}
 };
@@ -35,7 +35,7 @@ static void tclcmark_memory_panic()
  * allocator so we can directly use allocated memory as interpreter result.
  * We need wrappers because parameter types differ (int v/s size_t).
  */
-void *tclcmark_calloc(size_t nmem, size_t size)
+static void *tclcmark_calloc(size_t nmem, size_t size)
 {
     size_t nbytes;
     void *p;
@@ -51,14 +51,14 @@ void *tclcmark_calloc(size_t nmem, size_t size)
     return p;
 }
 
-void *tclcmark_realloc(void *p, size_t size)
+static void *tclcmark_realloc(void *p, size_t size)
 {
     if (size > INT_MAX)
         tclcmark_memory_panic();
     return ckrealloc(p, (int) size);
 }
 
-void tclcmark_free(void *p)
+static void tclcmark_free(void *p)
 {
     ckfree(p);
 }

--- a/tclcmark.m4
+++ b/tclcmark.m4
@@ -1,7 +1,20 @@
 AC_DEFUN(TCLCMARK_LOCATE_CMARK, [
+	AC_ARG_WITH(cmark-gfm,
+	    AC_HELP_STRING([--with-cmark-gfm=DIR],
+		[installation directory of cmark-gfm]),
+	    with_cmark_gfm="${withval}")
     AC_MSG_CHECKING([for cmark-gfm installation])
+    HAVECMARK=0
     CMARK_LIBS=""
-    HAVECMARK=`pkg-config --exists libcmark-gfm && echo "1"`
+    if test x"${with_cmark_gfm}" != x ; then
+        HAVECMARK=2
+        CMARK_CFLAGS="-I${with_cmark_gfm}/include"
+        CMARK_LIBS="${with_cmark_gfm}/lib/libcmark-gfm-extensions.a ${with_cmark_gfm}/lib/libcmark-gfm.a"
+	AC_MSG_RESULT([${with_cmark_gfm}])
+    else
+        HAVECMARK=`pkg-config --exists libcmark-gfm && echo "1"`
+    fi
+
     if test "$HAVECMARK" = "1" ; then
         AC_MSG_RESULT([found])
         if test "${TEA_PLATFORM}" = "windows" ; then
@@ -11,7 +24,9 @@ AC_DEFUN(TCLCMARK_LOCATE_CMARK, [
             CMARK_CFLAGS="`pkg-config --cflags libcmark-gfm`"
             CMARK_LIBS="`pkg-config --libs libcmark-gfm` -lcmark-gfmextensions"
         fi
-    else
+    fi
+
+    if test x"${CMARK_LIBS}" = x ; then
         AC_MSG_ERROR([The required lib libcmark-gfm not found])
     fi
 ])


### PR DESCRIPTION
- add `--with-cmark-gfm` to `configure`
- use internal linkage (`static`) for functions like `tclcmark_calloc`
- static library linking of cmark-gfm when use  `--with-cmark-gfm`